### PR TITLE
Add import logging to the streamer script.

### DIFF
--- a/streamer.py
+++ b/streamer.py
@@ -1,5 +1,6 @@
 
 import json
+import logging
 import websocket
 import gzip
 import io


### PR DESCRIPTION
The streamer script was also renamed from `streamer` to `streamer.py` to follow Python file naming conventions.