### PR TITLE
Fix: Use correct timestamp key 'T' for kline data

### DIFF
--- a/streamer.py
+++ b/streamer.py
@@ -41,9 +41,9 @@ class Test(object):
             data = json.loads(utf8_data)
             if data.get('dataType') == 'BTC-USDT@kline_3m' and data.get('data'):
                 for candle in data['data']:
-                    if all(k in candle for k in ('t', 'o', 'h', 'l', 'c', 'v')):
+                    if all(k in candle for k in ('T', 'o', 'h', 'l', 'c', 'v')):
                         new_candle = {
-                            'timestamp': pd.to_datetime(candle['t'], unit='ms'),
+                            'timestamp': pd.to_datetime(candle['T'], unit='ms'),
                             'open': float(candle['o']),
                             'high': float(candle['h']),
                             'low': float(candle['l']),


### PR DESCRIPTION
This commit fixes an issue where kline data was not being processed because the code was expecting the timestamp key to be 't' (lowercase) while the server was sending 'T' (uppercase).

- Updated the validation check in `on_message` to look for the correct timestamp key 'T'.
- Updated the data extraction logic to use `candle['T']` to get the timestamp.

This allows the script to correctly parse and process the kline data from the WebSocket stream.