### PR TITLE
Fix: Resolve pandas FutureWarning by using .loc to append rows

### DIFF
--- a/streamer.py
+++ b/streamer.py
@@ -67,8 +67,7 @@ class Test(object):
                             logging.info(f"3-min candle closed: Close={self.last_candle_update['close']} at {self.current_candle_timestamp}")
 
                             # Add the closed candle to the DataFrame
-                            closed_candle_df = pd.DataFrame([self.last_candle_update])
-                            self.df = pd.concat([self.df, closed_candle_df], ignore_index=True)
+                            self.df.loc[len(self.df)] = self.last_candle_update
 
                             # Start tracking the new candle
                             self.current_candle_timestamp = candle_timestamp


### PR DESCRIPTION
This commit resolves a `FutureWarning` from the pandas library that occurred when concatenating a new row to an empty DataFrame.

- The `pd.concat` method for appending the closed candle to the DataFrame has been replaced with the `.loc` accessor.
- The new implementation `self.df.loc[len(self.df)] = ...` is the recommended way to add a single row and avoids the warning.

This change ensures the script is using modern pandas practices and will be compatible with future versions of the library.