### PR TITLE
Fix: Set logging level to DEBUG to enable debug messages

### DIFF
--- a/streamer.py
+++ b/streamer.py
@@ -5,7 +5,7 @@ import gzip
 import io
 import pandas as pd
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s")
 
 URL="wss://open-api-swap.bingx.com/swap-market"
 CHANNEL= {"id":"e745cd6d-d0f6-4a70-8d5a-043e4c741b40","reqType": "sub","dataType":"BTC-USDT@kline_3m"}


### PR DESCRIPTION
This commit changes the logging level in `logging.basicConfig` from `INFO` to `DEBUG`.

The previous setting of `INFO` was preventing lower-level `DEBUG` messages from being displayed. This change ensures that all log messages, including `DEBUG`, are captured, which is useful for debugging and observing the script's behavior.