### PR TITLE
Feat: Add verbose debug logging for all raw messages

### DIFF
--- a/streamer.py
+++ b/streamer.py
@@ -35,6 +35,8 @@ class Test(object):
         decompressed_data = compressed_data.read()
         utf8_data = decompressed_data.decode('utf-8')
 
+        logging.debug("Raw message received: %s", utf8_data)
+
         if utf8_data == "Ping":
            ws.send("Pong")
            return


### PR DESCRIPTION
This commit adds a `logging.debug()` call to the beginning of the `on_message` handler to log every raw message received from the WebSocket.

This provides a verbose log stream at the DEBUG level for debugging and monitoring purposes, while keeping the INFO level log clean with only messages for closed candles. This change was made to satisfy the user's request for more detailed debug output.