### PR TITLE
Feat: Include full OHLCV data in closed candle log

### DIFF
--- a/streamer.py
+++ b/streamer.py
@@ -66,7 +66,12 @@ class Test(object):
                         # New candle detected, so the previous one has closed
                         if candle_timestamp > self.current_candle_timestamp:
                             # Log the closed candle
-                            logging.info(f"3-min candle closed: Close={self.last_candle_update['close']} at {self.current_candle_timestamp}")
+                            closed_candle = self.last_candle_update
+                            logging.info(
+                                f"3-min candle closed at {self.current_candle_timestamp}: "
+                                f"O={closed_candle['open']}, H={closed_candle['high']}, "
+                                f"L={closed_candle['low']}, C={closed_candle['close']}, V={closed_candle['volume']}"
+                            )
 
                             # Add the closed candle to the DataFrame
                             self.df.loc[len(self.df)] = self.last_candle_update


### PR DESCRIPTION
This commit updates the log message for a closed candle to include the full OHLCV (Open, High, Low, Close, Volume) data.

The previous log message only showed the closing price. This change provides a more complete summary of the candle in the log, as requested by the user.